### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,13 +88,13 @@ interruption selector method
     
     if (interuptionType == AVAudioSessionInterruptionTypeBegan)
         [self beginInterruption];
-#if __CC_PLATFORM_IOS >= 40000
+# if __CC_PLATFORM_IOS >= 40000
     else if (interuptionType == AVAudioSessionInterruptionTypeEnded)
         [self endInterruptionWithFlags:(NSUInteger)[interuptionDict valueForKey:AVAudioSessionInterruptionOptionKey]];
-#else
+# else
     else if (interuptionType == AVAudioSessionInterruptionTypeEnded)
         [self endInterruption];
-#endif
+# endif
 }
 ```
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
